### PR TITLE
Issue - Precompile assets

### DIFF
--- a/app/assets/stylesheets/bootstrap.css.scss
+++ b/app/assets/stylesheets/bootstrap.css.scss
@@ -1,0 +1,1 @@
+@import 'bootstrap/scss/bootstrap';

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,7 +10,6 @@ import "channels"
 
 import 'controllers';
 import 'bootstrap';
-import '../stylesheets/application';
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,1 +1,0 @@
-@import '~bootstrap/scss/bootstrap';


### PR DESCRIPTION
Apply a possible fix for precompiling assets on the prod environment issue, when pushing to Heroku

* Remove folder stylesheets from the javascript parent folder
* Update the application.js in the javascript/packs folder
* Create a new file bootstrap.css.scss in assets/stylesheets and import bootstrap